### PR TITLE
Handle image links

### DIFF
--- a/src/main/scala/io/prismic/PrismicJsonProtocol.scala
+++ b/src/main/scala/io/prismic/PrismicJsonProtocol.scala
@@ -23,17 +23,21 @@ object PrismicJsonProtocol extends DefaultJsonProtocol with NullOptions {
   }
 
   implicit object MediaLinkFormat extends RootJsonFormat[MediaLink] {
-    override def read(json: JsValue): MediaLink = (json \ "file") match {
-      case JsNull => parseJson(json \ "image")
-      case _ => parseJson(json \ "file")
-    }
-
-    def parseJson(json: JsValue): MediaLink = json.asJsObject.getFields("url", "kind", "size", "name") match {
+    override def read(json: JsValue): MediaLink = (json \ "file").asJsObject.getFields("url", "kind", "size", "name") match {
       case Seq(JsString(url), JsString(kind), JsString(size), JsString(name)) => MediaLink(url, kind, size.toLong, name)
       case _ => throw new DeserializationException("Missing field")
     }
 
     override def write(obj: MediaLink): JsValue = throw new SerializationException("Not implemented")
+  }
+
+  implicit object ImageLinkFormat extends RootJsonFormat[ImageLink] {
+    override def read(json: JsValue): ImageLink = (json \ "image").asJsObject.getFields("url", "kind", "size", "name") match {
+      case Seq(JsString(url), JsString(kind), JsString(size), JsString(name)) => ImageLink(url, kind, size.toLong, name)
+      case _ => throw new DeserializationException("Missing field")
+    }
+
+    override def write(obj: ImageLink): JsValue = throw new SerializationException("Not implemented")
   }
 
   implicit object DocumentLinkFormat extends RootJsonFormat[DocumentLink] {
@@ -62,7 +66,7 @@ object PrismicJsonProtocol extends DefaultJsonProtocol with NullOptions {
       case "Link.web" => json.convertTo[WebLink]
       case "Link.document" => json.convertTo[DocumentLink]
       case "Link.file" => json.convertTo[MediaLink]
-      case "Link.image" => json.convertTo[MediaLink]
+      case "Link.image" => json.convertTo[ImageLink]
       case t => throw new DeserializationException(s"Unkown link type $t")
     }
     override def write(obj: Link): JsValue = throw new SerializationException("Not implemented")
@@ -140,6 +144,7 @@ object PrismicJsonProtocol extends DefaultJsonProtocol with NullOptions {
         case Seq(JsString("Link.web"), link) => Hyperlink(start.toInt, end.toInt, link.convertTo[WebLink])
         case Seq(JsString("Link.document"), link) => Hyperlink(start.toInt, end.toInt, link.convertTo[DocumentLink])
         case Seq(JsString("Link.file"), link) => Hyperlink(start.toInt, end.toInt, link.convertTo[MediaLink])
+        case Seq(JsString("Link.image"), link) => Hyperlink(start.toInt, end.toInt, link.convertTo[ImageLink])
       }
       case Seq(JsString("label"), JsNumber(start), JsNumber(end), data) => StructuredText.Span.Label(start.toInt, end.toInt, (data \ "label").convertTo[String])
     }
@@ -245,7 +250,7 @@ object PrismicJsonProtocol extends DefaultJsonProtocol with NullOptions {
         case Seq(JsString("Link.web"), value) => value.convertTo[WebLink]
         case Seq(JsString("Link.document"), value) => value.convertTo[DocumentLink]
         case Seq(JsString("Link.file"), value) => value.convertTo[MediaLink]
-        case Seq(JsString("Link.image"), value) => value.convertTo[MediaLink]
+        case Seq(JsString("Link.image"), value) => value.convertTo[ImageLink]
         case Seq(JsString("StructuredText"), value) => value.convertTo[StructuredText]
         case Seq(JsString("Group"), value) => value.convertTo[Group]
         case Seq(JsString("Color"), value) => value.convertTo[Color]

--- a/src/main/scala/io/prismic/PrismicJsonProtocol.scala
+++ b/src/main/scala/io/prismic/PrismicJsonProtocol.scala
@@ -23,10 +23,16 @@ object PrismicJsonProtocol extends DefaultJsonProtocol with NullOptions {
   }
 
   implicit object MediaLinkFormat extends RootJsonFormat[MediaLink] {
-    override def read(json: JsValue): MediaLink = (json \ "file").asJsObject.getFields("url", "kind", "size", "name") match {
+    override def read(json: JsValue): MediaLink = (json \ "file") match {
+      case JsNull => parseJson(json \ "image")
+      case _ => parseJson(json \ "file")
+    }
+
+    def parseJson(json: JsValue): MediaLink = json.asJsObject.getFields("url", "kind", "size", "name") match {
       case Seq(JsString(url), JsString(kind), JsString(size), JsString(name)) => MediaLink(url, kind, size.toLong, name)
       case _ => throw new DeserializationException("Missing field")
     }
+
     override def write(obj: MediaLink): JsValue = throw new SerializationException("Not implemented")
   }
 
@@ -56,6 +62,7 @@ object PrismicJsonProtocol extends DefaultJsonProtocol with NullOptions {
       case "Link.web" => json.convertTo[WebLink]
       case "Link.document" => json.convertTo[DocumentLink]
       case "Link.file" => json.convertTo[MediaLink]
+      case "Link.image" => json.convertTo[MediaLink]
       case t => throw new DeserializationException(s"Unkown link type $t")
     }
     override def write(obj: Link): JsValue = throw new SerializationException("Not implemented")
@@ -238,6 +245,7 @@ object PrismicJsonProtocol extends DefaultJsonProtocol with NullOptions {
         case Seq(JsString("Link.web"), value) => value.convertTo[WebLink]
         case Seq(JsString("Link.document"), value) => value.convertTo[DocumentLink]
         case Seq(JsString("Link.file"), value) => value.convertTo[MediaLink]
+        case Seq(JsString("Link.image"), value) => value.convertTo[MediaLink]
         case Seq(JsString("StructuredText"), value) => value.convertTo[StructuredText]
         case Seq(JsString("Group"), value) => value.convertTo[Group]
         case Seq(JsString("Color"), value) => value.convertTo[Color]

--- a/src/main/scala/io/prismic/WithFragments.scala
+++ b/src/main/scala/io/prismic/WithFragments.scala
@@ -37,7 +37,8 @@ trait WithFragments {
     case a: WebLink      => Some(a)
     case a: MediaLink    => Some(a)
     case a: DocumentLink => Some(a)
-    case _                        => None
+    case a: ImageLink    => Some(a)
+    case _               => None
   }
 
   def getImage(field: String): Option[Image] = get(field).flatMap {

--- a/src/main/scala/io/prismic/fragments/package.scala
+++ b/src/main/scala/io/prismic/fragments/package.scala
@@ -18,6 +18,11 @@ case class MediaLink(url: String, kind: String, size: Long, filename: String) ex
   def asHtml: String = s"""<a href="$url">$filename</a>"""
 }
 
+case class ImageLink(url: String, kind: String, size: Long, filename: String) extends Link {
+  override def getUrl(linkResolver: DocumentLinkResolver) = url
+  def asHtml: String = s"""<img src="$url" alt="$filename"/>"""
+}
+
 case class DocumentLink(id: String,
                         uid: Option[String],
                         typ: String,

--- a/src/test/scala/FragmentSpec.scala
+++ b/src/test/scala/FragmentSpec.scala
@@ -68,7 +68,7 @@ class FragmentSpec extends Specification {
     val doc = query("""[[:d = at(document.id, "VVIOPCYAACgAyINK")]]""").results.head
     "support image media" in {
       doc getLink "article.icon" must beSome.like {
-        case l: Fragment.MediaLink => l.filename must_== "python-logo.png"
+        case l: ImageLink => l.filename must_== "python-logo.png"
       }
     }
   }

--- a/src/test/scala/FragmentSpec.scala
+++ b/src/test/scala/FragmentSpec.scala
@@ -62,6 +62,16 @@ class FragmentSpec extends Specification {
       }
     }
   }
+  "Link" should {
+    val api = await(Api.get("https://lesbonneschoses-vtjchiyaacyasekj.prismic.io/api"))
+    def query(q: String) = await(api.forms("everything").ref(api.master).query(q).submit())
+    val doc = query("""[[:d = at(document.id, "VVIOPCYAACgAyINK")]]""").results.head
+    "support image media" in {
+      doc getLink "article.icon" must beSome.like {
+        case l: Fragment.MediaLink => l.filename must_== "python-logo.png"
+      }
+    }
+  }
   "Timestamp" should {
     val json = JsObject(
       "type" -> JsString("Timestamp"),


### PR DESCRIPTION
Image links (type Link.image) were ignored.
I've implemented a class that renders to HTML `<img>` tags.
My new test uses my personal default-repository, so if the branch is merged the test repo should be updated to contain a fitting document and the test adapted... 